### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,7 @@ Actually package is worked, but requests time coudn't be calculated due to limit
 ## Installation
 Install package via a package manager: 
 ```bash
-# using npm
-npm install @artmizu/nuxt-prometheus
-
-# using yarn
-yarn add @artmizu/nuxt-prometheus
-
-# using pnpm
-pnpm add @artmizu/nuxt-prometheus
+npx nuxi@latest module add prometheus
 ```
 
 Add it to a modules section of your nuxt config:


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
