### PR TITLE
feat: move request measurement from nuxt hook to nitro

### DIFF
--- a/k6/load.test.js
+++ b/k6/load.test.js
@@ -5,7 +5,7 @@ import globalOptions from './options.js'
 export const options = globalOptions
 
 export default function () {
-  const res = http.get('http://192.168.1.17:3000/memory-measure')
+  const res = http.get('http://192.168.0.220:3000/memory-measure')
   check(res, {
     'is status 200': r => r.status === 200,
     'is contain elements': r => r.html('#response'),

--- a/k6/load.test.js
+++ b/k6/load.test.js
@@ -5,7 +5,7 @@ import globalOptions from './options.js'
 export const options = globalOptions
 
 export default function () {
-  const res = http.get('http://10.18.168.237:3000/c')
+  const res = http.get('http://192.168.1.17:3000/memory-measure')
   check(res, {
     'is status 200': r => r.status === 200,
     'is contain elements': r => r.html('#response'),

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "test:type": "vitest --typecheck.only --typecheck.ignoreSourceErrors --dir ./test",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "prepare": "husky"
+    "prepare": "husky",
+    "k6": "k6 run ./k6/load.test.js"
   },
   "dependencies": {
     "@mswjs/interceptors": "^0.36.10",

--- a/playground/pages/memory-measure.vue
+++ b/playground/pages/memory-measure.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { ofetch } from 'ofetch'
+
+const test = ofetch.create({
+  baseURL: 'https://jsonplaceholder.typicode.com',
+})
+
+const response = await test('/todos')
+
+if (import.meta.server) {
+  const mb = process.memoryUsage().heapUsed / 1024 / 1024
+  // eslint-disable-next-line no-console
+  console.log(`Memory usage: ${mb.toFixed(2)} MB`)
+}
+</script>
+
+<template>
+  <div>
+    <div id="response">
+      {{ response.data }}
+    </div>
+  </div>
+</template>

--- a/playground/server/api/complex/[id].ts
+++ b/playground/server/api/complex/[id].ts
@@ -1,0 +1,10 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(async (event) => {
+  const response = await fetch('https://jsonplaceholder.typicode.com/todos')
+  const data = await response.json()
+
+  return {
+    data,
+  }
+})

--- a/playground/server/api/complex/index.ts
+++ b/playground/server/api/complex/index.ts
@@ -1,0 +1,10 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(async () => {
+  const response = await fetch('https://jsonplaceholder.typicode.com/todos')
+  const data = await response.json()
+
+  return {
+    data,
+  }
+})

--- a/playground/server/api/plain/[id].ts
+++ b/playground/server/api/plain/[id].ts
@@ -1,0 +1,9 @@
+import { defineEventHandler, getRouterParams } from 'h3'
+
+export default defineEventHandler((event) => {
+  const params = getRouterParams(event)
+
+  return {
+    id: params.id,
+  }
+})

--- a/playground/server/api/plain/index.ts
+++ b/playground/server/api/plain/index.ts
@@ -1,0 +1,7 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler((event) => {
+  return {
+    status: 'ok',
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3425,6 +3425,11 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
 
+  nanoid@5.1.5:
+    resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
   nanotar@0.2.0:
     resolution: {integrity: sha512-9ca1h0Xjvo9bEkE4UOxgAzLV0jHKe6LMaxo37ND2DAhhAtd0j8pR1Wxz+/goMrZO8AEZTWCmyaOsFI/W5AdpCQ==}
 
@@ -6726,7 +6731,7 @@ snapshots:
       '@vue/devtools-kit': 7.7.2
       '@vue/devtools-shared': 7.7.2
       mitt: 3.0.1
-      nanoid: 5.1.3
+      nanoid: 5.1.5
       pathe: 2.0.3
       vite-hot-client: 0.2.4(vite@6.2.1(@types/node@18.19.80)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0))
       vue: 3.5.13(typescript@5.6.3)
@@ -8787,6 +8792,8 @@ snapshots:
   nanoid@3.3.9: {}
 
   nanoid@5.1.3: {}
+
+  nanoid@5.1.5: {}
 
   nanotar@0.2.0: {}
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,8 @@
+import 'h3';
+import type { NuxtPrometheusState } from './runtime/type';
+
+declare module 'h3' {
+  interface H3EventContext extends Record<string, any> {
+    prometheus: NuxtPrometheusState
+  }
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -16,7 +16,7 @@ const module: NuxtModule<Partial<AnalyticsModuleParams>> = defineNuxtModule<Part
     version,
     configKey: 'prometheus',
     compatibility: {
-      nuxt: '>=3.0.0 || ^2.16.0',
+      nuxt: '>=3.0.0 || ^2.16.0 || >=4.0.0',
       bridge: true,
     },
   },

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,5 @@
 import { defu } from 'defu'
-import { addPlugin, addServerHandler, createResolver, defineNuxtModule } from '@nuxt/kit'
+import { addPlugin, addServerHandler, addServerPlugin, createResolver, defineNuxtModule } from '@nuxt/kit'
 import type { NuxtModule } from '@nuxt/schema'
 import { name, version } from '../package.json'
 import type { AnalyticsModuleParams } from './runtime/type'
@@ -35,6 +35,8 @@ const module: NuxtModule<Partial<AnalyticsModuleParams>> = defineNuxtModule<Part
 
     const { resolve } = createResolver(import.meta.url)
     nuxt.options.build.transpile.push(resolve('runtime'))
+
+    addServerPlugin(resolve('./runtime/nitro'))
 
     addServerHandler({
       route: options.prometheusPath,

--- a/src/runtime/nitro.ts
+++ b/src/runtime/nitro.ts
@@ -50,8 +50,8 @@ export default defineNitroPlugin((nitroApp) => {
       },
     }
 
-    interceptor.on('request', event.context.prometheus.onRequest)
-    interceptor.on('response', event.context.prometheus.onResponse)
+    interceptor.on('request', event.context.prometheus.onRequest!)
+    interceptor.on('response', event.context.prometheus.onResponse!)
   })
 
   /**
@@ -59,8 +59,8 @@ export default defineNitroPlugin((nitroApp) => {
    * and to avoid blocking the request
    */
   nitroApp.hooks.hook('afterResponse', (event) => {
-    interceptor.off('request', event.context.prometheus.onRequest)
-    interceptor.off('response', event.context.prometheus.onResponse)
+    interceptor.off('request', event.context.prometheus.onRequest!)
+    interceptor.off('response', event.context.prometheus.onResponse!)
 
     const path = event.context.matchedRoute?.path === '/**' ? event.context?.prometheus?.path : event.context.matchedRoute?.path
     if (!path)

--- a/src/runtime/nitro.ts
+++ b/src/runtime/nitro.ts
@@ -1,0 +1,91 @@
+import { defineNitroPlugin, useRuntimeConfig } from 'nitropack/runtime'
+import { BatchInterceptor } from '@mswjs/interceptors'
+import { ClientRequestInterceptor } from '@mswjs/interceptors/ClientRequest'
+import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/XMLHttpRequest'
+import { FetchInterceptor } from '@mswjs/interceptors/fetch'
+import consola from 'consola'
+import { initMetrics, metrics } from './registry'
+import { calculateTime } from './utils'
+
+const interceptor = new BatchInterceptor({
+  name: 'nuxt-prometheus',
+  interceptors: [
+    new XMLHttpRequestInterceptor(),
+    new ClientRequestInterceptor(),
+    new FetchInterceptor(),
+  ],
+})
+
+interceptor.apply()
+
+export default defineNitroPlugin((nitroApp) => {
+  const params = useRuntimeConfig().public.prometheus
+  initMetrics(params)
+
+  nitroApp.hooks.hook('request', (event) => {
+    event.context.prometheus = {
+      start: Date.now(),
+      requests: {},
+      onRequest({ request }: { request: Request }) {
+        const url = new URL(request.url)
+
+        /**
+         * Exclude Nuxt requests to parts of the application, it's not about business-logic
+         */
+        const isNuxtRequest = /^\/__/.test(url.pathname)
+        if (isNuxtRequest)
+          return
+
+        event.context.prometheus.requests[request.url] = {
+          start: Date.now(),
+          end: Date.now(),
+        }
+
+        if (params.verbose)
+          consola.info(`[nuxt-prometheus] request: ${request.url}, ${new Date().toISOString()}`)
+      },
+      onResponse({ response }: { response: Response }) {
+        if (event.context.prometheus.requests[response.url])
+          event.context.prometheus.requests[response.url].end = Date.now()
+      },
+    }
+
+    interceptor.on('request', event.context.prometheus.onRequest)
+    interceptor.on('response', event.context.prometheus.onResponse)
+  })
+
+  /**
+   * Submit a data after the response for reducing latency for the user
+   * and to avoid blocking the request
+   */
+  nitroApp.hooks.hook('afterResponse', (event) => {
+    interceptor.off('request', event.context.prometheus.onRequest)
+    interceptor.off('response', event.context.prometheus.onResponse)
+
+    const path = event.context.matchedRoute?.path === '/**' ? event.context?.prometheus?.path : event.context.matchedRoute?.path
+    if (!path)
+      return
+
+    const time = calculateTime(event.context.prometheus)
+
+    metrics.renderTime?.labels(path).set(time.render)
+    metrics.requestTime?.labels(path).set(time.request)
+    metrics.totalTime?.labels(path).set(time.total)
+
+    if (params.verbose) {
+      consola.info(`[nuxt-prometheus] «${path}» api request time:`, time.request)
+      consola.info(`[nuxt-prometheus] «${path}» render time:`, time.render)
+      consola.info(`[nuxt-prometheus] «${path}» total time:`, time.total)
+    }
+  })
+
+  nitroApp.hooks.hook('error', (error, { event }) => {
+    if (event?.context.prometheus.onRequest)
+      interceptor.off('request', event.context.prometheus.onRequest)
+
+    if (event?.context.prometheus.onResponse)
+      interceptor.off('response', event.context.prometheus.onResponse)
+
+    return error
+  })
+})

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -2,8 +2,8 @@ export interface NuxtPrometheusState {
   path?: string
   start: number
   requests: Record<string, { start: number; end: number }>
-  onRequest: (event: { request: Request }) => void
-  onResponse: (event: { response: Response }) => void
+  onRequest?: (event: { request: Request }) => void
+  onResponse?: (event: { response: Response }) => void
 }
 
 export interface AnalyticsModuleParams {

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -1,12 +1,9 @@
-export interface AnalyticsModuleState {
-  path: string
+export interface NuxtPrometheusState {
+  path?: string
   start: number
-  requests: {
-    [key: string]: {
-      start: number
-      end: number
-    }
-  }
+  requests: Record<string, { start: number; end: number }>
+  onRequest: (event: { request: Request }) => void
+  onResponse: (event: { response: Response }) => void
 }
 
 export interface AnalyticsModuleParams {

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -1,6 +1,6 @@
-import type { AnalyticsModuleState } from './type'
+import type { NuxtPrometheusState } from './type'
 
-export function calculateTime(data: AnalyticsModuleState) {
+export function calculateTime(data: NuxtPrometheusState) {
   const result: { start: number; end: number }[] = []
   const list = Object.values(data.requests).reduce((reducer, current) => {
     const last = reducer[reducer.length - 1]

--- a/test/nuxt.spec.ts
+++ b/test/nuxt.spec.ts
@@ -32,17 +32,17 @@ describe('module tests', async () => {
     await page.goto(`${ctx.url}metrics`)
     const content = await page.innerText('body')
 
-    expect(content).toMatch(/page_render_time\{path=\"index: \/\"}\ \d+/gm)
-    expect(content).toMatch(/page_render_time\{path=\"a: \/a\"}\ \d+/gm)
-    expect(content).toMatch(/page_render_time\{path=\"b: \/b\"}\ \d+/gm)
+    expect(content).toMatch(/page_render_time\{path=\"\/\"}\ \d+/gm)
+    expect(content).toMatch(/page_render_time\{path=\"\/a\"}\ \d+/gm)
+    expect(content).toMatch(/page_render_time\{path=\"\/b\"}\ \d+/gm)
 
-    expect(content).toMatch(/page_request_time\{path=\"index: \/\"}\ \d+/gm)
-    expect(content).toMatch(/page_request_time\{path=\"a: \/a\"}\ \d+/gm)
-    expect(content).toMatch(/page_request_time\{path=\"b: \/b\"}\ \d+/gm)
+    expect(content).toMatch(/page_request_time\{path=\"\/\"}\ \d+/gm)
+    expect(content).toMatch(/page_request_time\{path=\"\/a\"}\ \d+/gm)
+    expect(content).toMatch(/page_request_time\{path=\"\/b\"}\ \d+/gm)
 
-    expect(content).toMatch(/page_total_time\{path=\"index: \/\"}\ \d+/gm)
-    expect(content).toMatch(/page_total_time\{path=\"a: \/a\"}\ \d+/gm)
-    expect(content).toMatch(/page_total_time\{path=\"b: \/b\"}\ \d+/gm)
+    expect(content).toMatch(/page_total_time\{path=\"\/\"}\ \d+/gm)
+    expect(content).toMatch(/page_total_time\{path=\"\/a\"}\ \d+/gm)
+    expect(content).toMatch(/page_total_time\{path=\"\/b\"}\ \d+/gm)
   })
 
   it('check the useFetch measuring time on /b route', async () => {
@@ -52,7 +52,7 @@ describe('module tests', async () => {
     await page.goto(`${ctx.url}metrics`)
     const content = await page.innerText('body')
 
-    expect(content).toMatch(/page_request_time\{path=\"b: \/b\"}\ [1-9]+/gm)
+    expect(content).toMatch(/page_request_time\{path=\"\/b\"}\ [1-9]+/gm)
   })
 
   it('check the native fetch measuring time on /c route', async () => {
@@ -62,6 +62,36 @@ describe('module tests', async () => {
     await page.goto(`${ctx.url}metrics`)
     const content = await page.innerText('body')
 
-    expect(content).toMatch(/page_request_time\{path=\"c: \/c\"}\ [1-9]+/gm)
+    expect(content).toMatch(/page_request_time\{path=\"\/c\"}\ [1-9]+/gm)
+  })
+
+  it('check server route without external requests', async () => {
+    const ctx = useTestContext()
+    const page = await createPage('/')
+    await page.goto(`${ctx.url}api/plain`)
+    await page.goto(`${ctx.url}api/plain/sample`)
+    await page.goto(`${ctx.url}metrics`)
+    const content = await page.innerText('body')
+
+    expect(content).toMatch(/page_render_time\{path=\"\/api\/plain\"}\ \d+/gm)
+    expect(content).toMatch(/page_render_time\{path=\"\/api\/plain\/\:id\"}\ \d+/gm)
+  })
+
+  it('check server route with external requests', async () => {
+    const ctx = useTestContext()
+    const page = await createPage('/')
+    await page.goto(`${ctx.url}api/complex`)
+    await page.goto(`${ctx.url}api/complex/sample`)
+    await page.goto(`${ctx.url}metrics`)
+    const content = await page.innerText('body')
+
+    expect(content).toMatch(/page_render_time\{path=\"\/api\/complex\"}\ \d+/gm)
+    expect(content).toMatch(/page_render_time\{path=\"\/api\/complex\/\:id\"}\ \d+/gm)
+
+    expect(content).toMatch(/page_request_time\{path=\"\/api\/complex\"}\ \d+/gm)
+    expect(content).toMatch(/page_request_time\{path=\"\/api\/complex\/\:id\"}\ \d+/gm)
+
+    expect(content).toMatch(/page_total_time\{path=\"\/api\/complex\"}\ \d+/gm)
+    expect(content).toMatch(/page_total_time\{path=\"\/api\/complex\/\:id\"}\ \d+/gm)
   })
 })


### PR DESCRIPTION
This approach allows us to get a more precise measurement, for example, it allows us to get the request time for the server routes.

#48 