### PR TITLE
Feat: add runtime environment variable support and metricsEndpoint option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ reports
 coverage
 *.lcov
 .nyc_output
+tsconfig.vitest-temp.json
 
 # VSCode
 .vscode

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,3 @@
 pnpm lint
 pnpm typecheck
-pnpm run test
+pnpm test -- --run

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,3 @@
 pnpm lint
 pnpm typecheck
-# pnpm vitest run
+pnpm run test

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Once the metrics have been collected by Prometheus, you will want to review them
 ## Options
 You can pass it through module options and the nuxt config property `prometheus`.
 
+### enabled
+- Type: `boolean`
+- Default: `true`
+- Description: Enables or disables Prometheus integration at runtime. When set to `false`, no metrics are collected and no hooks are registered. This allows you to build the app with the module but disable it in certain environments.
+
 ### verbose
 - Type: `boolean`
 - Default: `true`
@@ -68,3 +73,48 @@ You can pass it through module options and the nuxt config property `prometheus`
 - Type: `string`
 - Default: no prefix
 - Description: An optional prefix for metric names
+
+### metricsEndpoint
+- Type: `boolean`
+- Default: `true`
+- Description: Whether to expose the `/metrics` endpoint. When set to `false`, metrics are still collected internally but the endpoint is not registered. This allows you to access metrics programmatically via prom-client's `register` object and expose them on a separate internal port.
+
+## Runtime Environment Variables
+
+All options can be configured at runtime via environment variables following Nuxt's convention `NUXT_PUBLIC_PROMETHEUS_<OPTION_NAME>`:
+
+| Environment Variable | Option | Example |
+|---------------------|--------|---------|
+| `NUXT_PUBLIC_PROMETHEUS_ENABLED` | `enabled` | `false` |
+| `NUXT_PUBLIC_PROMETHEUS_VERBOSE` | `verbose` | `false` |
+| `NUXT_PUBLIC_PROMETHEUS_HEALTH_CHECK` | `healthCheck` | `false` |
+| `NUXT_PUBLIC_PROMETHEUS_METRICS_ENDPOINT` | `metricsEndpoint` | `false` |
+| `NUXT_PUBLIC_PROMETHEUS_PREFIX` | `prefix` | `myapp_` |
+| `NUXT_PUBLIC_PROMETHEUS_DISABLE_REQUEST_INTERCEPTOR` | `disableRequestInterceptor` | `true` |
+
+Example usage:
+```bash
+# Disable metrics endpoint in production while keeping collection active
+NUXT_PUBLIC_PROMETHEUS_METRICS_ENDPOINT=false node .output/server/index.mjs
+
+# Use custom prefix
+NUXT_PUBLIC_PROMETHEUS_PREFIX=myapp_ node .output/server/index.mjs
+```
+
+## Development
+
+```bash
+# Install dependencies
+pnpm install
+
+# Prepare the module (build types and module)
+pnpm run dev:prepare
+
+# Start development server with playground
+pnpm run dev
+
+# Run tests
+pnpm test
+```
+
+**Important:** After making changes to the module source code, you must run `pnpm run dev:prepare` to rebuild the module before testing.

--- a/src/module.ts
+++ b/src/module.ts
@@ -21,11 +21,13 @@ const module: NuxtModule<Partial<AnalyticsModuleParams>> = defineNuxtModule<Part
     },
   },
   defaults: {
+    enabled: true,
     verbose: true,
     healthCheck: true,
     prometheusPath: '/metrics',
     healthCheckPath: '/health',
     disableRequestInterceptor: false,
+    metricsEndpoint: true,
   },
   async setup(options, nuxt) {
     const moduleOptions = defu(
@@ -45,13 +47,11 @@ const module: NuxtModule<Partial<AnalyticsModuleParams>> = defineNuxtModule<Part
       handler: resolve('./runtime/handler'),
     })
 
-    if (options.healthCheck) {
-      addServerHandler({
-        route: options.healthCheckPath,
-        method: 'get',
-        handler: resolve('./runtime/health'),
-      })
-    }
+    addServerHandler({
+      route: options.healthCheckPath,
+      method: 'get',
+      handler: resolve('./runtime/health'),
+    })
 
     addPlugin({ src: resolve('./runtime/plugin'), mode: 'server' })
   },

--- a/src/runtime/handler.ts
+++ b/src/runtime/handler.ts
@@ -1,7 +1,17 @@
-import { defineEventHandler } from 'h3'
+import { createError, defineEventHandler } from 'h3'
+import { useRuntimeConfig } from 'nitropack/runtime'
 import { register } from 'prom-client'
 
 export default defineEventHandler(async (event) => {
+  const params = useRuntimeConfig().public.prometheus
+
+  if (!params.metricsEndpoint) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'Not Found',
+    })
+  }
+
   try {
     const data = await register.metrics()
     event.res.setHeader('Content-Type', register.contentType)

--- a/src/runtime/health.ts
+++ b/src/runtime/health.ts
@@ -1,5 +1,15 @@
-import { defineEventHandler } from 'h3'
+import { createError, defineEventHandler } from 'h3'
+import { useRuntimeConfig } from 'nitropack/runtime'
 
 export default defineEventHandler(() => {
+  const params = useRuntimeConfig().public.prometheus
+
+  if (!params.healthCheck) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'Not Found',
+    })
+  }
+
   return 'ok'
 })

--- a/src/runtime/nitro.ts
+++ b/src/runtime/nitro.ts
@@ -19,6 +19,9 @@ const interceptor = new BatchInterceptor({
 export default defineNitroPlugin((nitroApp) => {
   const params = useRuntimeConfig().public.prometheus
 
+  if (!params.enabled)
+    return
+
   if (!params.disableRequestInterceptor)
     interceptor.apply()
 

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,10 +1,15 @@
-import { defineNuxtPlugin, useRouter } from '#app'
+import { defineNuxtPlugin, useRouter, useRuntimeConfig } from '#app'
 
 /**
  * This plugin is used to add the current vue router path to the nitro context,
  * because vue router is not available in the nitro context.
  */
 export default defineNuxtPlugin((ctx) => {
+  const params = useRuntimeConfig().public.prometheus
+
+  if (!params.enabled)
+    return
+
   const router = useRouter()
   const path = router.currentRoute.value?.matched?.[0]?.path
 

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -8,6 +8,12 @@ export interface NuxtPrometheusState {
 
 export interface AnalyticsModuleParams {
   /**
+   * Enables or disables Prometheus integration at runtime.
+   * When false, no metrics are collected and no hooks are registered.
+   * @default true
+   */
+  enabled?: boolean
+  /**
    * stdout logs about external requests and render time of the page
    * @default true
    */
@@ -40,4 +46,12 @@ export interface AnalyticsModuleParams {
    * @default false
    */
   disableRequestInterceptor?: boolean
+
+  /**
+   * Whether to expose the metrics endpoint.
+   * When false, metrics are still collected but the endpoint is not registered.
+   * This allows you to access metrics programmatically via prom-client's register.
+   * @default true
+   */
+  metricsEndpoint?: boolean
 }

--- a/test/disable-metrics-endpoint.spec.ts
+++ b/test/disable-metrics-endpoint.spec.ts
@@ -1,0 +1,30 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { createPage, setup, useTestContext } from '@nuxt/test-utils/e2e'
+
+describe('disable metrics endpoint test', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('../playground', import.meta.url)),
+    nuxtConfig: {
+      prometheus: {
+        metricsEndpoint: false,
+      },
+    },
+  })
+
+  it('metrics endpoint should return 404 when disabled', async () => {
+    const ctx = useTestContext()
+    const page = await createPage('/')
+    await page.goto(`${ctx.url}metrics`)
+
+    expect(await page.innerText('body')).toContain('404')
+  })
+
+  it('health endpoint should still work', async () => {
+    const ctx = useTestContext()
+    const page = await createPage('/')
+    await page.goto(`${ctx.url}health`)
+
+    expect(await page.innerText('body')).toContain('ok')
+  })
+})

--- a/test/disable-module-env.spec.ts
+++ b/test/disable-module-env.spec.ts
@@ -1,0 +1,41 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { createPage, setup, useTestContext } from '@nuxt/test-utils/e2e'
+
+describe('disabled module via env variable test', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('../playground', import.meta.url)),
+    env: {
+      // Nuxt runtime config can be overridden via NUXT_PUBLIC_* env variables
+      NUXT_PUBLIC_PROMETHEUS_ENABLED: 'false',
+    },
+  })
+
+  it('metrics should not be collected when disabled via env variable', async () => {
+    const ctx = useTestContext()
+    const page = await createPage('/')
+
+    // Visit some pages to generate metrics (if they were being collected)
+    await page.goto(`${ctx.url}`)
+    await page.goto(`${ctx.url}a`)
+    await page.goto(`${ctx.url}metrics`)
+
+    const content = await page.innerText('body')
+
+    // Default Node.js metrics should not be present when module is disabled
+    expect(content).not.toMatch(/process_cpu_user_seconds_total/)
+
+    // Custom page metrics should not be present
+    expect(content).not.toMatch(/page_render_time/)
+    expect(content).not.toMatch(/page_request_time/)
+    expect(content).not.toMatch(/page_total_time/)
+  })
+
+  it('health endpoint should still work when module is disabled via env', async () => {
+    const ctx = useTestContext()
+    const page = await createPage('/')
+    await page.goto(`${ctx.url}health`)
+
+    expect(await page.innerText('body')).toContain('ok')
+  })
+})

--- a/test/disable-module.spec.ts
+++ b/test/disable-module.spec.ts
@@ -1,0 +1,42 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { createPage, setup, useTestContext } from '@nuxt/test-utils/e2e'
+
+describe('disabled module test', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('../playground', import.meta.url)),
+    nuxtConfig: {
+      prometheus: {
+        enabled: false,
+      },
+    },
+  })
+
+  it('metrics endpoint should not contain custom page metrics when disabled', async () => {
+    const ctx = useTestContext()
+    const page = await createPage('/')
+
+    // Visit some pages to generate metrics (if they were being collected)
+    await page.goto(`${ctx.url}`)
+    await page.goto(`${ctx.url}a`)
+    await page.goto(`${ctx.url}metrics`)
+
+    const content = await page.innerText('body')
+
+    // Default Node.js metrics should not be present when module is disabled
+    expect(content).not.toMatch(/process_cpu_user_seconds_total/)
+
+    // Custom page metrics should not be present
+    expect(content).not.toMatch(/page_render_time/)
+    expect(content).not.toMatch(/page_request_time/)
+    expect(content).not.toMatch(/page_total_time/)
+  })
+
+  it('health endpoint should still work when module is disabled', async () => {
+    const ctx = useTestContext()
+    const page = await createPage('/')
+    await page.goto(`${ctx.url}health`)
+
+    expect(await page.innerText('body')).toContain('ok')
+  })
+})

--- a/test/env-disable-interceptor.spec.ts
+++ b/test/env-disable-interceptor.spec.ts
@@ -1,0 +1,31 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { createPage, setup, useTestContext } from '@nuxt/test-utils/e2e'
+
+/**
+ * Test: NUXT_PUBLIC_PROMETHEUS_DISABLE_REQUEST_INTERCEPTOR env variable
+ * Verifies that request interception can be disabled via environment variable.
+ */
+describe('NUXT_PUBLIC_PROMETHEUS_DISABLE_REQUEST_INTERCEPTOR env variable', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('../playground', import.meta.url)),
+    env: {
+      NUXT_PUBLIC_PROMETHEUS_DISABLE_REQUEST_INTERCEPTOR: 'true',
+    },
+  })
+
+  it('should not track external request time when interceptor is disabled via env', async () => {
+    const ctx = useTestContext()
+    const page = await createPage('/')
+
+    // Visit route /b which makes external requests via useFetch
+    await page.goto(`${ctx.url}b`)
+    await page.goto(`${ctx.url}metrics`)
+
+    const content = await page.innerText('body')
+
+    // page_request_time should be 0 when interceptor is disabled
+    // (the metric exists but external requests are not tracked)
+    expect(content).toMatch(/playground_page_request_time\{path="\/b"\} 0/)
+  })
+})

--- a/test/env-healthcheck.spec.ts
+++ b/test/env-healthcheck.spec.ts
@@ -1,0 +1,33 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { createPage, setup, useTestContext } from '@nuxt/test-utils/e2e'
+
+/**
+ * Test: NUXT_PUBLIC_PROMETHEUS_HEALTH_CHECK env variable
+ * Verifies that the health check endpoint can be disabled via environment variable.
+ */
+describe('NUXT_PUBLIC_PROMETHEUS_HEALTH_CHECK env variable', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('../playground', import.meta.url)),
+    env: {
+      NUXT_PUBLIC_PROMETHEUS_HEALTH_CHECK: 'false',
+    },
+  })
+
+  it('should return 404 when health check is disabled via env', async () => {
+    const ctx = useTestContext()
+    const page = await createPage('/')
+    await page.goto(`${ctx.url}health`)
+
+    expect(await page.innerText('body')).toContain('404')
+  })
+
+  it('metrics endpoint should still work when health check is disabled', async () => {
+    const ctx = useTestContext()
+    const page = await createPage('/')
+    await page.goto(`${ctx.url}metrics`)
+
+    const content = await page.innerText('body')
+    expect(content).toMatch(/process_cpu_user_seconds_total/)
+  })
+})

--- a/test/env-metrics-endpoint.spec.ts
+++ b/test/env-metrics-endpoint.spec.ts
@@ -1,0 +1,33 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { createPage, setup, useTestContext } from '@nuxt/test-utils/e2e'
+
+/**
+ * Test: NUXT_PUBLIC_PROMETHEUS_METRICS_ENDPOINT env variable
+ * Verifies that the metrics endpoint can be disabled via environment variable
+ * while still collecting metrics internally.
+ */
+describe('NUXT_PUBLIC_PROMETHEUS_METRICS_ENDPOINT env variable', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('../playground', import.meta.url)),
+    env: {
+      NUXT_PUBLIC_PROMETHEUS_METRICS_ENDPOINT: 'false',
+    },
+  })
+
+  it('should return 404 when metrics endpoint is disabled via env', async () => {
+    const ctx = useTestContext()
+    const page = await createPage('/')
+    await page.goto(`${ctx.url}metrics`)
+
+    expect(await page.innerText('body')).toContain('404')
+  })
+
+  it('health endpoint should still work when metrics endpoint is disabled', async () => {
+    const ctx = useTestContext()
+    const page = await createPage('/')
+    await page.goto(`${ctx.url}health`)
+
+    expect(await page.innerText('body')).toContain('ok')
+  })
+})

--- a/test/env-prefix.spec.ts
+++ b/test/env-prefix.spec.ts
@@ -1,0 +1,31 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { createPage, setup, useTestContext } from '@nuxt/test-utils/e2e'
+
+/**
+ * Test: NUXT_PUBLIC_PROMETHEUS_PREFIX env variable
+ * Verifies that the metric prefix can be overridden via environment variable.
+ */
+describe('NUXT_PUBLIC_PROMETHEUS_PREFIX env variable', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('../playground', import.meta.url)),
+    env: {
+      NUXT_PUBLIC_PROMETHEUS_PREFIX: 'env_prefix_',
+    },
+  })
+
+  it('should use custom prefix from env variable', async () => {
+    const ctx = useTestContext()
+    const page = await createPage('/')
+
+    await page.goto(`${ctx.url}`)
+    await page.goto(`${ctx.url}metrics`)
+
+    const content = await page.innerText('body')
+
+    // Metrics should have the custom prefix from env variable
+    // This overrides the playground's default 'playground_' prefix
+    expect(content).toMatch(/env_prefix_process_cpu_user_seconds_total/)
+    expect(content).toMatch(/env_prefix_page_render_time/)
+  })
+})

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -2,6 +2,39 @@ import { expectTypeOf, test } from 'vitest'
 import type { NuxtConfig } from 'nuxt/config'
 import type { AnalyticsModuleParams } from '../src/runtime/type'
 
-test('is module types exist', () => {
+test('module types match NuxtConfig', () => {
   expectTypeOf<Partial<AnalyticsModuleParams>>().toMatchTypeOf<NuxtConfig['prometheus']>()
+})
+
+test('AnalyticsModuleParams has correct property types', () => {
+  // Boolean properties
+  expectTypeOf<AnalyticsModuleParams['enabled']>().toEqualTypeOf<boolean | undefined>()
+  expectTypeOf<AnalyticsModuleParams['verbose']>().toEqualTypeOf<boolean>()
+  expectTypeOf<AnalyticsModuleParams['healthCheck']>().toEqualTypeOf<boolean>()
+  expectTypeOf<AnalyticsModuleParams['disableRequestInterceptor']>().toEqualTypeOf<boolean | undefined>()
+  expectTypeOf<AnalyticsModuleParams['metricsEndpoint']>().toEqualTypeOf<boolean | undefined>()
+
+  // String properties
+  expectTypeOf<AnalyticsModuleParams['healthCheckPath']>().toEqualTypeOf<string>()
+  expectTypeOf<AnalyticsModuleParams['prometheusPath']>().toEqualTypeOf<string>()
+  expectTypeOf<AnalyticsModuleParams['prefix']>().toEqualTypeOf<string | undefined>()
+})
+
+test('config is assignable with all options', () => {
+  const config: Partial<AnalyticsModuleParams> = {
+    enabled: true,
+    verbose: false,
+    healthCheck: true,
+    healthCheckPath: '/health',
+    prometheusPath: '/metrics',
+    prefix: 'myapp_',
+    disableRequestInterceptor: false,
+    metricsEndpoint: true,
+  }
+  expectTypeOf(config).toMatchTypeOf<Partial<AnalyticsModuleParams>>()
+})
+
+test('config is assignable with minimal options', () => {
+  const minimalConfig: Partial<AnalyticsModuleParams> = {}
+  expectTypeOf(minimalConfig).toMatchTypeOf<Partial<AnalyticsModuleParams>>()
 })


### PR DESCRIPTION
### Summary
- Add runtime configuration support via `NUXT_PUBLIC_PROMETHEUS_*` environment variables
- Add new `enabled` option to completely disable the module at runtime
- Add new `metricsEndpoint` option to disable the `/metrics` endpoint while still collecting metrics internally