### PR TITLE
feat: Add `page_total_requests` counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ In addition to the [default Node.js metrics](https://github.com/siimon/prom-clie
 | `page_render_time_summary` | Summary | `path` | Distribution of page render times, in ms |
 | `page_request_time_summary` | Summary | `path` | Distribution of external API request times, in ms |
 | `page_total_time_summary` | Summary | `path` | Distribution of total request times, in ms |
+| `page_total_requests` | Counter | `path` | Number of requests received per each page |
 
 All custom metric names can be prefixed using the `prefix` option (e.g., `myapp_page_render_time`).
 

--- a/src/runtime/nitro.ts
+++ b/src/runtime/nitro.ts
@@ -82,6 +82,8 @@ export default defineNitroPlugin((nitroApp) => {
     metrics.requestTimeSummary?.labels(path).observe(time.request)
     metrics.totalTimeSummary?.labels(path).observe(time.total)
 
+    metrics.totalRequests?.labels(path).inc()
+
     if (params.verbose) {
       consola.info(`[nuxt-prometheus] «${path}» api request time:`, time.request)
       consola.info(`[nuxt-prometheus] «${path}» render time:`, time.render)

--- a/src/runtime/registry.ts
+++ b/src/runtime/registry.ts
@@ -1,5 +1,5 @@
 import type { AnalyticsModuleParams } from './type'
-import { collectDefaultMetrics, Gauge, register, Summary } from 'prom-client'
+import { collectDefaultMetrics, Counter, Gauge, register, Summary } from 'prom-client'
 
 export const metrics = {
   /** If `true`, metrics was initialized with `initMetrics` */
@@ -14,6 +14,9 @@ export const metrics = {
   renderTimeSummary: null as Summary | null,
   requestTimeSummary: null as Summary | null,
   totalTimeSummary: null as Summary | null,
+
+  // Counter
+  totalRequests: null as Counter | null,
 }
 
 export function initMetrics(p: Partial<AnalyticsModuleParams>) {
@@ -60,6 +63,12 @@ export function initMetrics(p: Partial<AnalyticsModuleParams>) {
   metrics.totalTimeSummary = new Summary({
     name: `${prefix}page_total_time_summary`,
     help: 'Total time it took to complete a request',
+    labelNames: ['path'],
+  })
+
+  metrics.totalRequests = new Counter({
+    name: `${prefix}page_total_requests`,
+    help: 'Number of requests received per each page',
     labelNames: ['path'],
   })
 

--- a/test/nuxt.spec.ts
+++ b/test/nuxt.spec.ts
@@ -56,6 +56,11 @@ describe('module tests', async () => {
     expect(content).toMatch(/page_total_time_summary_count\{path="\/"\} [1-9]\d*/g)
     expect(content).toMatch(/page_total_time_summary_count\{path="\/a"\} [1-9]\d*/g)
     expect(content).toMatch(/page_total_time_summary_count\{path="\/b"\} [1-9]\d*/g)
+
+    // Counter metrics
+    expect(content).toMatch(/page_total_requests\{path="\/"\} [1-9]\d*/g)
+    expect(content).toMatch(/page_total_requests\{path="\/a"\} [1-9]\d*/g)
+    expect(content).toMatch(/page_total_requests\{path="\/b"\} [1-9]\d*/g)
   })
 
   it('check the useFetch measuring time on /b route', async () => {
@@ -107,6 +112,7 @@ describe('module tests', async () => {
   it('check server route with external requests', async () => {
     const ctx = useTestContext()
     const page = await createPage('/')
+
     await page.goto(`${ctx.url}api/complex`)
     await page.goto(`${ctx.url}api/complex/sample`)
     await page.goto(`${ctx.url}metrics`)


### PR DESCRIPTION
Currently `nuxt-prometheus` exposes multiple time related metrics: render time, request time, total time.

When the render time goes up it is hard to know why.

The render time might increase if the server has received more requests.

Add a counter for the number of requests the server has received.
