### PR TITLE
fix: avoid registering disabled health check route

### DIFF
--- a/playground/pages/health.vue
+++ b/playground/pages/health.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Nuxt render health OK</div>
+</template>

--- a/src/module.ts
+++ b/src/module.ts
@@ -46,11 +46,13 @@ const module: NuxtModule<Partial<AnalyticsModuleParams>> = defineNuxtModule<Part
       handler: resolve('./runtime/handler'),
     })
 
-    addServerHandler({
-      route: options.healthCheckPath,
-      method: 'get',
-      handler: resolve('./runtime/health'),
-    })
+    if (options.healthCheck) {
+      addServerHandler({
+        route: options.healthCheckPath,
+        method: 'get',
+        handler: resolve('./runtime/health'),
+      })
+    }
 
     addPlugin({ src: resolve('./runtime/plugin'), mode: 'server' })
   },

--- a/test/disable-healthcheck.spec.ts
+++ b/test/disable-healthcheck.spec.ts
@@ -12,11 +12,11 @@ describe('custom module params test', async () => {
     },
   })
 
-  it('health page check', async () => {
+  it('allows an app health page when disabled by nuxt config', async () => {
     const ctx = useTestContext()
     const page = await createPage('/')
     await page.goto(`${ctx.url}health`)
 
-    expect(await page.textContent('body')).toContain('404')
+    expect(await page.textContent('body')).toContain('Nuxt render health OK')
   })
 })


### PR DESCRIPTION
I want to have a healthcheck on `/health` managed by me, as I have several different parts of my app that I need to verify before I know it is healthy.

With nuxt-prometheus, the healthcheck can be disabled by setting `healthCheck: false` under `prometheus` in `nuxt.config.ts`. This does not disable the route from being registered by nuxt-prometheus however, it simply makes nuxt-prometheus return `404` instead of `200 OK`, which prevents me from using that route.

Nuxt-prometheus *used* to conditionally register these routes based on the config (added in #7), but this was changed in #79 to accommodate configuration by environment variables, the issue being that routes have to be registered before environment variables are available.

In this PR I have included both guards. If configured through Nuxt config, the route is not registered. If configured through environment variables, the route returns 404, matching old behavior.