### PR TITLE
fix: bind interceptor listeners once to stop memory leak under load

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -38,6 +38,14 @@ const module: NuxtModule<Partial<AnalyticsModuleParams>> = defineNuxtModule<Part
     const { resolve } = createResolver(import.meta.url)
     nuxt.options.build.transpile.push(resolve('runtime'))
 
+    // Needed to attribute outbound requests made during SSR render to the
+    // request being handled. A user's explicit setting is preserved by defu.
+    nuxt.options.nitro = defu(nuxt.options.nitro, {
+      experimental: {
+        asyncContext: true,
+      },
+    })
+
     addServerPlugin(resolve('./runtime/nitro'))
 
     addServerHandler({

--- a/src/runtime/interceptor.ts
+++ b/src/runtime/interceptor.ts
@@ -1,0 +1,81 @@
+import type { NuxtPrometheusState } from './type'
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { BatchInterceptor } from '@mswjs/interceptors'
+import { ClientRequestInterceptor } from '@mswjs/interceptors/ClientRequest'
+import { FetchInterceptor } from '@mswjs/interceptors/fetch'
+import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/XMLHttpRequest'
+import consola from 'consola'
+
+export const interceptor = new BatchInterceptor({
+  name: 'nuxt-prometheus',
+  interceptors: [
+    new XMLHttpRequestInterceptor(),
+    new ClientRequestInterceptor(),
+    new FetchInterceptor(),
+  ],
+})
+
+export const requestContext = new AsyncLocalStorage<NuxtPrometheusState>()
+
+let resolveState: () => NuxtPrometheusState | undefined = () => requestContext.getStore()
+
+export function setStateResolver(resolver: () => NuxtPrometheusState | undefined): void {
+  resolveState = resolver
+}
+
+function isNuxtInternalRequest(url: string): boolean {
+  try {
+    return /^\/__/.test(new URL(url).pathname)
+  }
+  catch {
+    return false
+  }
+}
+
+let listenersBound = false
+
+// Bind a single listener pair for the process lifetime; the old code attached a
+// fresh pair per request and leaked them when cleanup hooks did not fire.
+export function bindInterceptor({ verbose = false }: { verbose?: boolean } = {}): void {
+  if (listenersBound)
+    return
+  listenersBound = true
+
+  interceptor.on('request', ({ request }: { request: Request }) => {
+    const state = resolveState()
+    if (!state)
+      return
+
+    if (isNuxtInternalRequest(request.url))
+      return
+
+    const now = Date.now()
+    state.requests[request.url] = { start: now, end: now }
+
+    if (verbose)
+      consola.info(`[nuxt-prometheus] request: ${request.url}, ${new Date(now).toISOString()}`)
+  })
+
+  interceptor.on('response', ({ response }: { response: Response }) => {
+    const state = resolveState()
+    if (!state)
+      return
+
+    const data = state.requests[response.url]
+    if (data)
+      data.end = Date.now()
+  })
+}
+
+// Total listeners across the batched interceptors, for the leak tests.
+export function interceptorListenerCount(event: 'request' | 'response'): number {
+  const children = (interceptor as unknown as { interceptors: Array<{ emitter: { listenerCount: (e: string) => number } }> }).interceptors
+  return children.reduce((total, child) => total + child.emitter.listenerCount(event), 0)
+}
+
+export function resetInterceptorForTests(): void {
+  interceptor.removeAllListeners('request')
+  interceptor.removeAllListeners('response')
+  listenersBound = false
+  resolveState = () => requestContext.getStore()
+}

--- a/src/runtime/nitro.ts
+++ b/src/runtime/nitro.ts
@@ -1,20 +1,9 @@
-import { BatchInterceptor } from '@mswjs/interceptors'
-import { ClientRequestInterceptor } from '@mswjs/interceptors/ClientRequest'
-import { FetchInterceptor } from '@mswjs/interceptors/fetch'
-import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/XMLHttpRequest'
+import type { NuxtPrometheusState } from './type'
 import consola from 'consola'
-import { defineNitroPlugin, useRuntimeConfig } from 'nitropack/runtime'
+import { defineNitroPlugin, useEvent, useRuntimeConfig } from 'nitropack/runtime'
+import { bindInterceptor, interceptor, requestContext, setStateResolver } from './interceptor'
 import { initMetrics, metrics } from './registry'
 import { calculateTime } from './utils'
-
-const interceptor = new BatchInterceptor({
-  name: 'nuxt-prometheus',
-  interceptors: [
-    new XMLHttpRequestInterceptor(),
-    new ClientRequestInterceptor(),
-    new FetchInterceptor(),
-  ],
-})
 
 export default defineNitroPlugin((nitroApp) => {
   const params = useRuntimeConfig().public.prometheus
@@ -22,57 +11,46 @@ export default defineNitroPlugin((nitroApp) => {
   if (!params.enabled)
     return
 
-  if (!params.disableRequestInterceptor)
+  if (!params.disableRequestInterceptor) {
+    // Nitro's async context wraps the whole handler, including the SSR render,
+    // so outbound requests fired during rendering are attributed correctly.
+    setStateResolver(() => {
+      try {
+        const state = useEvent().context.prometheus as NuxtPrometheusState | undefined
+        if (state)
+          return state
+      }
+      catch {}
+      return requestContext.getStore()
+    })
+
     interceptor.apply()
+    bindInterceptor({ verbose: params.verbose })
+  }
 
   initMetrics(params)
 
   nitroApp.hooks.hook('request', (event) => {
-    event.context.prometheus = {
+    const state: NuxtPrometheusState = {
       start: Date.now(),
       requests: {},
-      onRequest({ request }: { request: Request }) {
-        const url = new URL(request.url)
-
-        /**
-         * Exclude Nuxt requests to parts of the application, it's not about business-logic
-         */
-        const isNuxtRequest = /^\/__/.test(url.pathname)
-        if (isNuxtRequest)
-          return
-
-        event.context.prometheus.requests[request.url] = {
-          start: Date.now(),
-          end: Date.now(),
-        }
-
-        if (params.verbose)
-          consola.info(`[nuxt-prometheus] request: ${request.url}, ${new Date().toISOString()}`)
-      },
-      onResponse({ response }: { response: Response }) {
-        const data = event.context.prometheus.requests[response.url]
-        if (data)
-          data.end = Date.now()
-      },
     }
-
-    interceptor.on('request', event.context.prometheus.onRequest!)
-    interceptor.on('response', event.context.prometheus.onResponse!)
+    event.context.prometheus = state
+    // Fallback attribution for outbound requests that stay in this async context.
+    requestContext.enterWith(state)
   })
 
-  /**
-   * Submit a data after the response for reducing latency for the user
-   * and to avoid blocking the request
-   */
+  // Submit data after the response so it does not add latency to the request.
   nitroApp.hooks.hook('afterResponse', (event) => {
-    interceptor.off('request', event.context.prometheus.onRequest!)
-    interceptor.off('response', event.context.prometheus.onResponse!)
+    const state = event.context.prometheus
+    if (!state)
+      return
 
-    const path = event.context.matchedRoute?.path === '/**' ? event.context?.prometheus?.path : event.context.matchedRoute?.path
+    const path = event.context.matchedRoute?.path === '/**' ? state.path : event.context.matchedRoute?.path
     if (!path)
       return
 
-    const time = calculateTime(event.context.prometheus)
+    const time = calculateTime(state)
 
     metrics.renderTime?.labels(path).set(time.render)
     metrics.requestTime?.labels(path).set(time.request)
@@ -87,15 +65,5 @@ export default defineNitroPlugin((nitroApp) => {
       consola.info(`[nuxt-prometheus] «${path}» render time:`, time.render)
       consola.info(`[nuxt-prometheus] «${path}» total time:`, time.total)
     }
-  })
-
-  nitroApp.hooks.hook('error', (error, { event }) => {
-    if (event?.context.prometheus.onRequest)
-      interceptor.off('request', event.context.prometheus.onRequest)
-
-    if (event?.context.prometheus.onResponse)
-      interceptor.off('response', event.context.prometheus.onResponse)
-
-    return error
   })
 })

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -2,8 +2,6 @@ export interface NuxtPrometheusState {
   path?: string
   start: number
   requests: Record<string, { start: number, end: number }>
-  onRequest?: (event: { request: Request }) => void
-  onResponse?: (event: { response: Response }) => void
 }
 
 export interface AnalyticsModuleParams {

--- a/test/interceptor-leak.spec.ts
+++ b/test/interceptor-leak.spec.ts
@@ -1,0 +1,119 @@
+import type { NuxtPrometheusState } from '../src/runtime/type'
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  bindInterceptor,
+  interceptor,
+  interceptorListenerCount,
+  requestContext,
+  resetInterceptorForTests,
+} from '../src/runtime/interceptor'
+
+function newState(): NuxtPrometheusState {
+  return { start: Date.now(), requests: {} }
+}
+
+beforeEach(() => {
+  resetInterceptorForTests()
+  interceptor.apply()
+})
+
+// Before: the original design attached a listener per request and detached it
+// only from the afterResponse/error hooks, leaking any request that skipped them.
+describe('regression: per-request listeners leaked (original behaviour)', () => {
+  it('accumulates listeners when per-request cleanup does not run', () => {
+    // One `on` fans out across the sub-interceptors; measure the per-listener cost.
+    const base = interceptorListenerCount('request')
+    const probe = (): void => {}
+    interceptor.on('request', probe)
+    const perListener = interceptorListenerCount('request') - base
+    interceptor.off('request', probe)
+
+    const start = interceptorListenerCount('request')
+
+    // 100 requests attach a listener like the old hook did; 3 in 10 never reach
+    // cleanup (aborted connection, hijacked/streamed response, early error).
+    for (let i = 0; i < 100; i++) {
+      const listener = (): void => {}
+      interceptor.on('request', listener)
+      if (i % 10 < 7)
+        interceptor.off('request', listener)
+    }
+
+    expect(interceptorListenerCount('request') - start).toBe(30 * perListener)
+
+    resetInterceptorForTests()
+  })
+})
+
+// After: a single listener pair is bound once and the active request is
+// resolved from async context.
+describe('fixed: interceptor is bound once and does not leak under load', () => {
+  it('registers a single listener pair regardless of request volume', async () => {
+    bindInterceptor()
+    const boundRequest = interceptorListenerCount('request')
+    const boundResponse = interceptorListenerCount('response')
+
+    expect(boundRequest).toBeGreaterThan(0)
+
+    for (let i = 0; i < 1000; i++)
+      await requestContext.run(newState(), async () => {})
+
+    // Repeated plugin init must stay a no-op.
+    bindInterceptor()
+    bindInterceptor({ verbose: true })
+
+    expect(interceptorListenerCount('request')).toBe(boundRequest)
+    expect(interceptorListenerCount('response')).toBe(boundResponse)
+  })
+
+  it('attributes an outbound request to the active request context', async () => {
+    bindInterceptor()
+    // Resolve locally so the test never hits the network.
+    interceptor.on('request', ({ controller }: { controller: { respondWith: (r: Response) => void } }) => {
+      controller.respondWith(new Response('ok'))
+    })
+
+    const state = newState()
+    await requestContext.run(state, async () => {
+      await fetch('http://api.test/v1/flights')
+    })
+
+    expect(Object.keys(state.requests)).toContain('http://api.test/v1/flights')
+    const record = state.requests['http://api.test/v1/flights']
+    expect(record).toBeDefined()
+    if (record)
+      expect(record.end).toBeGreaterThanOrEqual(record.start)
+  })
+
+  it('does not cross-record outbound calls between concurrent requests', async () => {
+    bindInterceptor()
+    interceptor.on('request', ({ controller }: { controller: { respondWith: (r: Response) => void } }) => {
+      controller.respondWith(new Response('ok'))
+    })
+
+    const a = newState()
+    const b = newState()
+
+    await Promise.all([
+      requestContext.run(a, () => fetch('http://api.test/a')),
+      requestContext.run(b, () => fetch('http://api.test/b')),
+    ])
+
+    expect(Object.keys(a.requests)).toEqual(['http://api.test/a'])
+    expect(Object.keys(b.requests)).toEqual(['http://api.test/b'])
+  })
+
+  it('ignores internal Nuxt (/__*) outbound requests', async () => {
+    bindInterceptor()
+    interceptor.on('request', ({ controller }: { controller: { respondWith: (r: Response) => void } }) => {
+      controller.respondWith(new Response('ok'))
+    })
+
+    const state = newState()
+    await requestContext.run(state, async () => {
+      await fetch('http://api.test/__nuxt_island/foo')
+    })
+
+    expect(Object.keys(state.requests)).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Closes #93

- Bind one listener pair for the process lifetime.
- Resolve the active request from Nitro async context (`useEvent()`, wraps the
  SSR render), with the request-hook context as fallback.
- Enable `experimental.asyncContext` via `defu` (preserves explicit user setting).
- Drop the per-request `on`/`off` churn and the fragile `error`-hook cleanup.
